### PR TITLE
Fix the code of conduct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository allows folks to collect topics and conferences for use with the Python Community News newsletter, podcast, and livestream.
 
 ## Code of Conduct
-Please review the [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
+Please review the [Code of Conduct](https://github.com/Python-Community-News/.github/blob/main/CODE_OF_CONDUCT.md) before contributing.
 
 ## License
 This project is licensed under the terms of the MIT license. See the [LICENSE](LICENSE.md) file.


### PR DESCRIPTION
The code of conduct is now stored in the organization's .github repository instead of in each project repository. This change updates the readme to point to the correct location.