### PR TITLE
Minor updates to GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_news_topic.yml
+++ b/.github/ISSUE_TEMPLATE/add_news_topic.yml
@@ -1,14 +1,14 @@
 name: Add News Topic
 description: Add a topic that you would like shared on the show and in the newsletter
 title: "[Topic]: <TITLE OF POST>"
-labels: ["Content"]
+labels: ["content"]
 body:
   - type: input
     id: url
     attributes:
       label: URL
       description: Url of the source
-      placeholder: ex. email@example.com
+      placeholder: ex. https://example.com
     validations:
       required: true
   - type: input
@@ -22,14 +22,13 @@ body:
       label: Summary
       description: Provide a summary (2-5 sentences) of what the content is about
       placeholder: A thing happened that will affect the Python Community
-      value: "A thing happened that will affect the Python Community"
     validations:
       required: true
   - type: checkboxes
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/Python-Community-News/.github/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I would like my name mentioned on the podcast
         - label: I agree to follow this project's Code of Conduct

--- a/.github/ISSUE_TEMPLATE/name:add_conference.yml
+++ b/.github/ISSUE_TEMPLATE/name:add_conference.yml
@@ -70,7 +70,8 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/Python-Community-News/.github/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I would like my name mentioned on the podcast
         - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
- Lowercase the `content` label to match the case of the label used on GitHub. Fixes #13.
- Replace the email format placeholder for conference websites with a URL formatted placeholder.
- Remove the default value from the summary field for news topics in favor of displaying the existing placeholder.
- Update links to code of conduct to point to the PCN document.