### PR TITLE
Change conference description to summary

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_conference.yml
+++ b/.github/ISSUE_TEMPLATE/add_conference.yml
@@ -61,7 +61,7 @@ body:
     attributes:
       label: Summary
       description: Summary of the news you're sharing about this conference.
-      placeholder: "PyCon has been announced alongside it's [website](url) and [cfp]. The conference is 27-31 April with workshops and sprints"
+      placeholder: "PyCon US has been announced alongside it's [website](url) and [cfp]. The conference is 27-31 April with workshops and sprints"
     validations:
       required: false
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/add_conference.yml
+++ b/.github/ISSUE_TEMPLATE/add_conference.yml
@@ -59,9 +59,9 @@ body:
   - type: textarea
     id: conference_description
     attributes:
-      label: Conference Description
-      description: Add any pertinent information about the conference e.g. focuses, topics, talk-length
-      placeholder: "This is a general python conference with open spaces and sprints"
+      label: Summary
+      description: Summary of the news you're sharing about this conference.
+      placeholder: "PyCon has been announced alongside it's [website](url) and [cfp]. The conference is 27-31 April with workshops and sprints"
     validations:
       required: false
   - type: checkboxes


### PR DESCRIPTION
To make a little more generic. I'd like to change to "Summary".

The big reason is that we're making the conference news posts a little more generic and adding summary may.

I've also updated the description and added a sample placeholder.