### PR TITLE
Remove Badge with Next Recording Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # Python Community News - Topics
-![Days until next Podcast](https://img.shields.io/endpoint?url=https://pcn-days-until-badge.azurewebsites.net/api/badgedaysuntil) ![Days until Topic Deadline](https://img.shields.io/endpoint?url=https://pcn-days-until-badge.azurewebsites.net/api/badgetopicsduedate)
-
-
 
 This repository allows folks to collect topics and conferences for use with the Python Community News newsletter, podcast, and livestream.
 


### PR DESCRIPTION
With us moving to streaming monthly, we should remove the values as they are no longer accurate.